### PR TITLE
wip: stream tool calling support

### DIFF
--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -722,6 +722,8 @@ class LLMRawResponse(ComputedPropertyMixin, BaseModelExtended):
     finish_reason: Optional[str] = None
     error: Optional[ErrorResponse] = None
 
+    tool_calls: Optional[List[ToolCall]] = None
+
     @model_validator(mode="before")
     @classmethod
     def text_or_error_or_finish_reason(cls, values):

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -144,12 +144,16 @@ class ResponsePostprocessor:
             async for batched_results in generator:
                 for result in batched_results.unpack():
                     all_results.append(result)
-
+                    
                     if result.error:
                         logger.error(f"{result.error}")
                         # Drop finish reason as OpenAI doesn't expect it
                         # for errors in streaming
                         result.finish_reason = None
+                        logger.error(
+                            f"Reporting back an error: {result.error}",
+                            extra={"ray_serve_extra_fields": {"response": str(result)}},
+                        )
                         all_results.pop()
                         had_error = True
 
@@ -159,6 +163,7 @@ class ResponsePostprocessor:
 
                     else:
                         finish_reason = result.finish_reason
+                        tool_calls = result.tool_calls if hasattr(result, 'tool_calls') else []
 
                         if not yielded_role:
                             choices = [
@@ -177,6 +182,37 @@ class ResponsePostprocessor:
                             )
                             yielded_role = True
 
+                        # Handle tool calls
+                        if tool_calls:
+                            for tool_call in tool_calls:
+                                choices = [
+                                    ChatCompletionResponseStreamChoice(
+                                        delta=DeltaMessage(
+                                            content="",
+                                            tool_calls=[
+                                                ToolCall(
+                                                    id=tool_call.id,
+                                                    type=tool_call.type,
+                                                    function=FunctionCall(
+                                                        name=tool_call.function.name,
+                                                        arguments=tool_call.function.arguments
+                                                    )
+                                                )
+                                            ]
+                                        ),
+                                        index=0,
+                                        finish_reason="function_call",
+                                        logprobs=None,
+                                    )
+                                ]
+                                yield ChatCompletionStreamResponse(
+                                    id=completion_id,
+                                    model=model,
+                                    choices=choices,
+                                    usage=None,
+                                )
+
+                        # Handle regular text response
                         logprobs = None
                         if result.logprobs:
                             logprobs = ChatCompletionLogProbs(

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -2,6 +2,8 @@ import asyncio
 import os
 import time
 from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, TYPE_CHECKING
+import json
+import uuid
 
 import ray
 import re
@@ -613,6 +615,10 @@ class VLLMEngine(LLMEngine):
                     log_probs_idx,
                     request.sampling_params.top_logprobs,
                 )
+
+                # Check for tool calls in the generated text
+                tool_calls = self._detect_tool_calls(text_output)
+                
                 yield LLMRawResponse(
                     generated_text=text_output,
                     num_generated_tokens=tokens_collected,
@@ -623,6 +629,7 @@ class VLLMEngine(LLMEngine):
                     preprocessing_time=0,
                     generation_time=clock.reset_interval(),
                     finish_reason=finish_reason,
+                    tool_calls=tool_calls,
                 )
 
             if request_output is not None:
@@ -863,11 +870,52 @@ class VLLMEngine(LLMEngine):
             # returned to the user is correct.
             raise ValidationError(str(e)) from e
 
-    @staticmethod
+    def _detect_tool_calls(self, text: str) -> Optional[List[ToolCall]]:
+        """Detect tool calls in the generated text.
+
+        Tool calls are expected to be in JSON format and start with "{".
+        
+        Returns:
+            List of ToolCall objects if tool calls are found, None otherwise.
+        """
+        if not text:
+            return None
+            
+        try:
+            # Look for JSON-like tool call patterns
+            tool_calls = []
+            start_idx = 0
+            while start_idx < len(text):
+                tool_start = text.find("{", start_idx)
+                if tool_start == -1:
+                    break
+                    
+                tool_end = text.find("}", tool_start)
+                if tool_end == -1:
+                    break
+                    
+                tool_json = text[tool_start:tool_end + 1]
+                tool_data = json.loads(tool_json)
+                
+                if isinstance(tool_data, dict) and "name" in tool_data:
+                    tool_calls.append(ToolCall(
+                        id=str(uuid.uuid4()),
+                        type="function",
+                        function=FunctionCall(
+                            name=tool_data["name"],
+                            arguments=tool_data.get("arguments", "{}")
+                        )
+                    ))
+                    
+                start_idx = tool_end + 1
+                
+            return tool_calls if tool_calls else None
+            
+        except (json.JSONDecodeError, KeyError):
+            return None
+
     def _extract_logprobs(
-        output: "RequestOutput",
-        log_probs_idx: int,
-        top_logprobs: Optional[int] = None,
+        self, output: "RequestOutput", log_probs_idx: int, top_logprobs: Optional[int] = None,
     ) -> Tuple[List[LogProbs], int]:
         all_log_probs = output.logprobs[log_probs_idx:] if output.logprobs else None
         return_log_probs = []


### PR DESCRIPTION
Updated as below 

1. VLLM.generate() method needs to detect tool calls.
2. LLMRawResponse has been updated to include tool calls information.
3.  _chat_completions_wrapper in the LLMServer must process results that contain tool calls from the batched results of the generator.
4. function_call has been updated to serve as the finish_reason (unsure).